### PR TITLE
Remove warnings for perl version 5.24.1.

### DIFF
--- a/scripts/hip2unicode
+++ b/scripts/hip2unicode
@@ -158,12 +158,12 @@ open (INFILE, $infile) || die ("Cannot read from $infile: $!");
 
 				# STEP ZERO: REMOVE COMMENTS
 				if ($opt_f eq "tex") {
-					$p =~ s/\%{(.+)}/||$1||/g;
+					$p =~ s/\%[{](.+)}/||$1||/g;
 				} elsif ($opt_f eq "html" || $opt_f eq "xml") {
-					$p =~ s/\%{(.+)}/<!-- $1 -->/g;
+					$p =~ s/\%[{](.+)}/<!-- $1 -->/g;
 					# we may have a comment spanning two or more lines
 					# in this, case convert the front
-					$p =~ s/\%{/<!-- /;
+					$p =~ s/\%[{]/<!-- /;
 					# set the comment flag
 					$isINCOMMENT = 1;
 					# check if we're in comment to convert the back


### PR DESCRIPTION
Executing hip2unicode script output warnings: Unescaped left brace in
regex is deprecated, passed through in regex; marked by <-- HERE in
.......... line [161|163|166]

See http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22%7B%22_should_now_be_escaped_in_a_pattern for details.